### PR TITLE
Fix isLogin check for questions page

### DIFF
--- a/js/questions.js
+++ b/js/questions.js
@@ -249,5 +249,17 @@ class QuizManager {
     }
 }
 
-const quizManager = new QuizManager();
-quizManager.startQuestions();
+async function init() {
+    const isLoggedIn = await isLogin()
+    if(isLoggedIn === false) {
+        window.location.href = './login.html'
+        return
+    } else if (isLoggedIn === null) {
+        return
+    }
+    document.body.style.display = 'block'
+    const quizManager = new QuizManager();
+    quizManager.startQuestions();
+}
+
+init()


### PR DESCRIPTION
Since isLogin got changed to just return boolean, this page now needs to call it and deal with the result (to show to the page)